### PR TITLE
Refactors Grammar to support opts and own expansion strings

### DIFF
--- a/src/derivation_tree.rs
+++ b/src/derivation_tree.rs
@@ -6,8 +6,11 @@ use std::ops::Deref;
 
 #[derive(Debug)]
 pub enum Node {
+    /// T is a `Terminal Node`
     T(String),
+    /// N is a `Nonterminal Node` that has not been expanded yet
     N(String),
+    /// EN is an `Expanded Nonterminal Node`
     EN(String, Children),
 }
 
@@ -48,6 +51,7 @@ impl Children {
 }
 
 impl From<&str> for Children {
+    /// splits an expansion-string into terminal and nonterminal symbols and lift them into Node::T and Node::N
     fn from(expansion: &str) -> Self {
         let tokens = parser::tokens(expansion);
         if tokens.is_empty() {
@@ -69,17 +73,18 @@ impl From<&str> for Children {
 
 impl Node {
     pub fn new_nonterminal(sym: &str) -> Self {
-        Node::N(sym.to_owned())
+        Node::N(String::from(sym))
     }
 
     pub fn new_terminal(sym: &str) -> Self {
-        Node::T(sym.to_owned())
+        Node::T(String::from(sym))
     }
 
     pub fn new_expanded(sym: &str, children: Children) -> Self {
-        Node::EN(sym.to_owned(), children)
+        Node::EN(String::from(sym), children)
     }
 
+    /// any_possible_expansions returns true when there is a Node::N in a subtree
     pub fn any_possible_expansions(&self) -> bool {
         match self {
             Node::T(_) => false,
@@ -90,6 +95,7 @@ impl Node {
         }
     }
 
+    /// any_possible_expansions returns the number of Node::N in a subtree
     pub fn num_possible_expansions(&self) -> usize {
         match self {
             Node::T(_) => 0,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -2,20 +2,76 @@
 
 use super::parser::{self, Token};
 use super::shared::add_to_set;
+
 use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::ops::Deref;
 
-pub type Expansions<'a> = HashMap<&'a str, Vec<&'a str>>;
-
-#[derive(Debug)]
-pub struct Grammar<'a> {
-    expansions: Expansions<'a>,
+pub struct Expansion<T> {
+    pub string: String,
+    pub opts: Option<T>,
 }
 
-impl<'a> Grammar<'a> {
-    pub fn new(expansions: Expansions<'a>) -> Self {
+impl<T> Expansion<T> {
+    pub fn new(string: &str, opts: Option<T>) -> Self {
+        Expansion {
+            string: String::from(string),
+            opts,
+        }
+    }
+}
+
+impl<T> fmt::Debug for Expansion<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.string)
+    }
+}
+
+pub type Alternatives<T> = Vec<Expansion<T>>;
+
+pub type Expansions<T> = HashMap<String, Alternatives<T>>;
+
+#[derive(Debug)]
+pub struct Grammar<T> {
+    expansions: Expansions<T>,
+}
+
+impl<T> Deref for Grammar<T> {
+    type Target = Expansions<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.expansions
+    }
+}
+
+impl From<HashMap<&str, Vec<&str>>> for Grammar<()> {
+    fn from(input: HashMap<&str, Vec<&str>>) -> Self {
+        let expansions = input
+            .iter()
+            .map(|(symbol, expansions)| {
+                (
+                    String::from(*symbol),
+                    expansions
+                        .iter()
+                        .map(|exp| Expansion {
+                            string: String::from(*exp),
+                            opts: None,
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+
+        Grammar::new(expansions)
+    }
+}
+
+impl<T> Grammar<T> {
+    pub fn new(expansions: Expansions<T>) -> Self {
         Grammar { expansions }
     }
 
+    /// symbol_cost is the minimum of the potential expansion costs
     pub fn symbol_cost(&self, symbol: &str, seen: &HashSet<&str>) -> f64 {
         self[symbol]
             .iter()
@@ -23,8 +79,10 @@ impl<'a> Grammar<'a> {
             .fold(f64::INFINITY, |min, c| if min < c { min } else { c })
     }
 
-    pub fn expansion_cost(&self, expansion: &str, seen: &HashSet<&str>) -> f64 {
-        let nonterminals = nonterminal_tokens(expansion);
+    /// expansion_cost is sum of the nonterminal symbol costs plus 1
+    /// if we have visited one of the nonterminal symbols in the expansion before, the cost is infinity
+    pub fn expansion_cost(&self, expansion: &Expansion<T>, seen: &HashSet<&str>) -> f64 {
+        let nonterminals = nonterminal_tokens(&expansion.string);
         if nonterminals.is_empty() {
             return 1.0;
         }
@@ -40,13 +98,14 @@ impl<'a> Grammar<'a> {
         cost
     }
 
+    /// is_valid_grammar looks for unreachable nonterminals, reachable nonterminals and unavoidable cycles
     pub fn is_valid_grammar(&self, start_symbol: Option<&str>) -> bool {
         let start_symbol = start_symbol.unwrap_or("<start>");
         let reachable_nonterminals = self.find_reachable_nonterminals(start_symbol);
-        let defined_nonterminals: HashSet<&str> = self.keys().map(|t| *t).collect();
+        let defined_nonterminals: HashSet<&str> = self.keys().map(|t| t.as_str()).collect();
         let unreachable_nonterminals = &defined_nonterminals - &reachable_nonterminals;
         let undefined_nonterminals = &reachable_nonterminals - &defined_nonterminals;
-        let cycle = self.find_unavoidable_cycle(start_symbol);
+        let cycle = self.find_unavoidable_cycle();
         if !unreachable_nonterminals.is_empty() {
             println!("unreachable nonterminals: {:?}", unreachable_nonterminals);
         }
@@ -59,9 +118,10 @@ impl<'a> Grammar<'a> {
         undefined_nonterminals.is_empty() & cycle.is_empty()
     }
 
-    fn find_reachable_nonterminals<'b>(&'b self, sym: &'b str) -> HashSet<&'b str> {
+    /// find_reachable_nonterminals returns reachable nonterminal symbols from a start symbol
+    fn find_reachable_nonterminals<'a>(&'a self, symbol: &'a str) -> HashSet<&'a str> {
         let mut result = HashSet::new();
-        let mut frontier = vec![sym];
+        let mut frontier = vec![symbol];
         while !frontier.is_empty() {
             let sym = frontier.pop().unwrap();
             if result.contains(sym) {
@@ -70,15 +130,16 @@ impl<'a> Grammar<'a> {
             result.insert(sym);
             if let Some(expansions) = self.get(sym) {
                 for expansion in expansions {
-                    frontier.extend(nonterminal_tokens(expansion));
+                    frontier.extend(nonterminal_tokens(&expansion.string));
                 }
             }
         }
         result
     }
 
-    fn find_unavoidable_cycle<'b>(&'b self, _start_symbol: &'b str) -> Vec<&'b str> {
-        let defined_nonterminals: Vec<&str> = self.keys().map(|t| *t).collect();
+    /// find_unavoidable_cycle returns the nonterminal symbols that appear in any unavoidable cycles
+    fn find_unavoidable_cycle(&self) -> Vec<&str> {
+        let defined_nonterminals: Vec<&str> = self.keys().map(|t| t.as_str()).collect();
         let costs: Vec<f64> = defined_nonterminals
             .iter()
             .map(|token| self.symbol_cost(token, &HashSet::new()))
@@ -93,15 +154,7 @@ impl<'a> Grammar<'a> {
     }
 }
 
-use std::ops::Deref;
-impl<'a> Deref for Grammar<'a> {
-    type Target = Expansions<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.expansions
-    }
-}
-
+/// nonterminal_tokens returns the nonterminal symbols in the same order as the input string
 fn nonterminal_tokens(input: &str) -> Vec<&str> {
     parser::tokens(input)
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,6 @@ pub mod strategy;
 
 pub use derivation_tree::{Children, Node};
 pub use extensions::ebnf_to_bnf;
-pub use grammar::{Expansions, Grammar};
+pub use grammar::{Expansion, Expansions, Grammar};
 pub use grammar_fuzzer::GrammarFuzzer;
 pub use strategy::{CloseStrategy, GrowthStrategy, RandomStrategy, Strategy};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,15 @@
-use ebnffuzzer::extensions::{ebnf_to_bnf, OExpansions};
+use ebnffuzzer::extensions::ebnf_to_bnf;
+use ebnffuzzer::Grammar;
 use ebnffuzzer::GrammarFuzzer;
 use ebnffuzzer::Node;
 use ebnffuzzer::{CloseStrategy, GrowthStrategy, RandomStrategy, Strategy};
-use ebnffuzzer::{Expansions, Grammar};
+use std::collections::HashMap;
 
 use std::cmp::Ordering;
 use std::time::Instant;
 
-fn json_grammar() -> OExpansions {
-    let expansios: Expansions = [
+fn json_grammar() -> Grammar<()> {
+    let expansios: HashMap<_, _> = [
         ("<start>", vec!["<assoc>"]),
         (
             "<value>",
@@ -29,21 +30,23 @@ fn json_grammar() -> OExpansions {
     .cloned()
     .collect();
 
-    OExpansions::from(&Grammar::new(expansios))
+    Grammar::from(expansios)
 }
 
 fn main() {
+    // Fuzzer
     let expansion = GrowthStrategy::new(0, 1000);
     let random = RandomStrategy::new(40, 8000);
     let close = CloseStrategy::new();
-    let strategies: Vec<&dyn Strategy> = vec![&expansion, &random, &close];
+    let strategies: Vec<&dyn Strategy<()>> = vec![&expansion, &random, &close];
 
     let ebnf_json_grammar = json_grammar();
     let json_grammar = ebnf_to_bnf(&ebnf_json_grammar);
-    let json_grammar = Grammar::from(&json_grammar);
     assert_eq!(json_grammar.is_valid_grammar(None), true);
 
     let fuzzer = GrammarFuzzer::new(json_grammar, &strategies);
+
+    // Sample
     let mut stat = Vec::new();
     for _ in 0..100 {
         let mut node = Node::N("<start>".to_owned());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,6 +31,7 @@ fn token(input: &str) -> IResult<&str, Token> {
     alt((nonterminal_token, terminal_token))(input)
 }
 
+/// tokens returns a sequence of terminal an nonterminal tokens
 pub fn tokens(input: &str) -> Vec<Token> {
     // it should consume the whole input
     let (input, tokens) = many0(token)(input).unwrap();
@@ -62,6 +63,7 @@ fn parenthesized_expression(input: &str) -> IResult<&str, ParenthesizedExpressio
     Ok((_input, parenthesized_expression))
 }
 
+/// next_parenthesized_expression returns the next paranthesized expression in the input string
 pub fn next_parenthesized_expression(input: &str) -> Option<ParenthesizedExpression> {
     match many_till(take(1usize), parenthesized_expression)(input) {
         Ok((_, (_, pe))) => Some(pe),
@@ -93,6 +95,7 @@ fn extended_nonterminal(input: &str) -> IResult<&str, ExtendedNonterminal> {
     Ok((_input, extended_nonterminal))
 }
 
+/// next_extended_nonterminal returns the next extended nonterminal
 pub fn next_extended_nonterminal(input: &str) -> Option<ExtendedNonterminal> {
     match many_till(take(1usize), extended_nonterminal)(input) {
         Ok((_, (_, en))) => Some(en),

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -3,12 +3,14 @@
 use rand::seq::SliceRandom;
 use std::collections::HashSet;
 
-pub fn add_to_set<'a>(s: &HashSet<&'a str>, e: &'a str) -> HashSet<&'a str> {
+/// add_to_set returns a new set that includes the element
+pub fn add_to_set<'a>(s: &HashSet<&'a str>, element: &'a str) -> HashSet<&'a str> {
     let mut new_set = s.clone();
-    new_set.insert(e);
+    new_set.insert(element);
     new_set
 }
 
+/// selects randomly from the set of indicies of min value elements
 pub fn min_idx(vs: &Vec<f64>) -> usize {
     assert_eq!(vs.is_empty(), false);
     let min = vs
@@ -23,6 +25,7 @@ pub fn min_idx(vs: &Vec<f64>) -> usize {
     *random_element(&min_idxs, |_| true).unwrap()
 }
 
+/// selects randomly from the set of indicies of max value elements
 pub fn max_idx(vs: &Vec<f64>) -> usize {
     assert_eq!(vs.is_empty(), false);
     let max = vs
@@ -37,6 +40,7 @@ pub fn max_idx(vs: &Vec<f64>) -> usize {
     *random_element(&max_idxs, |_| true).unwrap()
 }
 
+/// random_element selects a random element satisfying the predicate
 pub fn random_element<T, F>(vs: &Vec<T>, p: F) -> Option<&T>
 where
     F: Fn(&T) -> bool,


### PR DESCRIPTION
- Adds comments
- Extends Grammar to support opts
- Introduces an Expansion struct that owns the expansion string and opts

---

I have also implemented a version of this where Node and Grammar only keep references to the symbols and expansion-strings >> https://github.com/corvuslabs/grammar-fuzzer/pull/2