### PR TITLE
Extends grammar to support opts

### DIFF
--- a/src/derivation_tree.rs
+++ b/src/derivation_tree.rs
@@ -5,18 +5,18 @@ use std::cell::RefCell;
 use std::ops::Deref;
 
 #[derive(Debug)]
-pub enum Node {
-    T(String),
-    N(String),
-    EN(String, Children),
+pub enum Node<'a> {
+    T(&'a str),
+    N(&'a str),
+    EN(&'a str, Children<'a>),
 }
 
 #[derive(Debug)]
-pub struct Children {
-    pub roots: Vec<RefCell<Node>>,
+pub struct Children<'a> {
+    pub roots: Vec<RefCell<Node<'a>>>,
 }
 
-impl std::fmt::Display for Node {
+impl<'a> std::fmt::Display for Node<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match &self {
             Node::T(sym) => write!(f, "{}", sym),
@@ -31,27 +31,27 @@ impl std::fmt::Display for Node {
     }
 }
 
-impl Deref for Children {
-    type Target = Vec<RefCell<Node>>;
+impl<'a> Deref for Children<'a> {
+    type Target = Vec<RefCell<Node<'a>>>;
 
     fn deref(&self) -> &Self::Target {
         &self.roots
     }
 }
 
-impl Children {
-    pub fn epsilon() -> Self {
+impl<'a> Children<'a> {
+    pub fn new_terminal(symbol: &'a str) -> Self {
         Children {
-            roots: vec![RefCell::new(Node::new_terminal(""))],
+            roots: vec![RefCell::new(Node::new_terminal(symbol))],
         }
     }
 }
 
-impl From<&str> for Children {
-    fn from(expansion: &str) -> Self {
+impl<'a> From<&'a str> for Children<'a> {
+    fn from(expansion: &'a str) -> Self {
         let tokens = parser::tokens(expansion);
         if tokens.is_empty() {
-            return Children::epsilon();
+            return Children::new_terminal("");
         }
 
         let roots = tokens
@@ -67,17 +67,17 @@ impl From<&str> for Children {
     }
 }
 
-impl Node {
-    pub fn new_nonterminal(sym: &str) -> Self {
-        Node::N(sym.to_owned())
+impl<'a> Node<'a> {
+    pub fn new_nonterminal(sym: &'a str) -> Self {
+        Node::N(sym)
     }
 
-    pub fn new_terminal(sym: &str) -> Self {
-        Node::T(sym.to_owned())
+    pub fn new_terminal(sym: &'a str) -> Self {
+        Node::T(sym)
     }
 
-    pub fn new_expanded(sym: &str, children: Children) -> Self {
-        Node::EN(sym.to_owned(), children)
+    pub fn new_expanded(sym: &'a str, children: Children<'a>) -> Self {
+        Node::EN(sym, children)
     }
 
     pub fn any_possible_expansions(&self) -> bool {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -2,28 +2,58 @@
 
 use super::parser::{self, Token};
 use super::shared::add_to_set;
+
 use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::ops::Deref;
 
-pub type Expansions<'a> = HashMap<&'a str, Vec<&'a str>>;
+// ------------------------------------ Types ---------------------------------
 
-#[derive(Debug)]
-pub struct Grammar<'a> {
-    expansions: Expansions<'a>,
+pub type Symbol<'a> = &'a str;
+
+pub struct Expansion<'a, T> {
+    pub symbol: Symbol<'a>,
+    pub opts: Option<T>,
 }
 
-impl<'a> Grammar<'a> {
-    pub fn new(expansions: Expansions<'a>) -> Self {
+pub type Expansions<'a, T> = HashMap<Symbol<'a>, Vec<Expansion<'a, T>>>;
+
+#[derive(Debug)]
+pub struct Grammar<'a, T> {
+    expansions: Expansions<'a, T>,
+}
+
+// ---------------------------------- Expansion -------------------------------
+
+impl<'a, T> fmt::Debug for Expansion<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.symbol)
+    }
+}
+
+impl<'a, T> Deref for Expansion<'a, T> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.symbol
+    }
+}
+
+// ---------------------------------- Grammar ---------------------------------
+
+impl<'a, T> Grammar<'a, T> {
+    pub fn new(expansions: Expansions<'a, T>) -> Self {
         Grammar { expansions }
     }
 
-    pub fn symbol_cost(&self, symbol: &str, seen: &HashSet<&str>) -> f64 {
+    pub fn symbol_cost(&self, symbol: Symbol, seen: &HashSet<Symbol>) -> f64 {
         self[symbol]
             .iter()
             .map(|expansion| self.expansion_cost(expansion, &add_to_set(seen, symbol)))
             .fold(f64::INFINITY, |min, c| if min < c { min } else { c })
     }
 
-    pub fn expansion_cost(&self, expansion: &str, seen: &HashSet<&str>) -> f64 {
+    pub fn expansion_cost(&self, expansion: &Expansion<T>, seen: &HashSet<Symbol>) -> f64 {
         let nonterminals = nonterminal_tokens(expansion);
         if nonterminals.is_empty() {
             return 1.0;
@@ -40,13 +70,13 @@ impl<'a> Grammar<'a> {
         cost
     }
 
-    pub fn is_valid_grammar(&self, start_symbol: Option<&str>) -> bool {
+    pub fn is_valid_grammar(&self, start_symbol: Option<Symbol>) -> bool {
         let start_symbol = start_symbol.unwrap_or("<start>");
         let reachable_nonterminals = self.find_reachable_nonterminals(start_symbol);
         let defined_nonterminals: HashSet<&str> = self.keys().map(|t| *t).collect();
         let unreachable_nonterminals = &defined_nonterminals - &reachable_nonterminals;
         let undefined_nonterminals = &reachable_nonterminals - &defined_nonterminals;
-        let cycle = self.find_unavoidable_cycle(start_symbol);
+        let cycle = self.find_unavoidable_cycle();
         if !unreachable_nonterminals.is_empty() {
             println!("unreachable nonterminals: {:?}", unreachable_nonterminals);
         }
@@ -59,7 +89,7 @@ impl<'a> Grammar<'a> {
         undefined_nonterminals.is_empty() & cycle.is_empty()
     }
 
-    fn find_reachable_nonterminals<'b>(&'b self, sym: &'b str) -> HashSet<&'b str> {
+    fn find_reachable_nonterminals(&self, sym: Symbol<'a>) -> HashSet<Symbol<'a>> {
         let mut result = HashSet::new();
         let mut frontier = vec![sym];
         while !frontier.is_empty() {
@@ -77,7 +107,7 @@ impl<'a> Grammar<'a> {
         result
     }
 
-    fn find_unavoidable_cycle<'b>(&'b self, _start_symbol: &'b str) -> Vec<&'b str> {
+    fn find_unavoidable_cycle(&self) -> Vec<Symbol> {
         let defined_nonterminals: Vec<&str> = self.keys().map(|t| *t).collect();
         let costs: Vec<f64> = defined_nonterminals
             .iter()
@@ -93,17 +123,16 @@ impl<'a> Grammar<'a> {
     }
 }
 
-use std::ops::Deref;
-impl<'a> Deref for Grammar<'a> {
-    type Target = Expansions<'a>;
+impl<'a, T> Deref for Grammar<'a, T> {
+    type Target = Expansions<'a, T>;
 
     fn deref(&self) -> &Self::Target {
         &self.expansions
     }
 }
 
-fn nonterminal_tokens(input: &str) -> Vec<&str> {
-    parser::tokens(input)
+fn nonterminal_tokens<'a, T>(input: &Expansion<'a, T>) -> Vec<Symbol<'a>> {
+    parser::tokens(input.symbol)
         .iter()
         .filter(|t| match t {
             Token::Nonterminal(_) => true,


### PR DESCRIPTION
In this implementation Grammar and the Derivation Tree don't own the symbols and expansion string. Because of this I had to explicitly add lifetimes which can make it more difficult to read.