### PR TITLE
Implements From trait for Grammar to support conversion from &str and String expansions

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -16,7 +16,7 @@
 //! .cloned()
 //! .collect();
 //!
-//! let ebnf_grammar = Grammar::from(ebnf_grammar);
+//! let ebnf_grammar = Grammar::from(&ebnf_grammar);
 //!
 //! let bnf_grammar = ebnf_to_bnf(&ebnf_grammar);
 //! ```
@@ -185,7 +185,7 @@ mod tests {
         .cloned()
         .collect();
 
-        let ebnf_grammar = Grammar::from(ebnf_grammar);
+        let ebnf_grammar = Grammar::from(&ebnf_grammar);
 
         let expected_bnf_grammar: HashMap<&str, Vec<&str>> = [
             ("<list>", vec!["[<symbol-3><string>]"]),
@@ -202,7 +202,7 @@ mod tests {
         .cloned()
         .collect();
 
-        let expected_bnf_grammar = Grammar::from(expected_bnf_grammar);
+        let expected_bnf_grammar = Grammar::from(&expected_bnf_grammar);
 
         assert_eq!(ebnf_to_bnf(&ebnf_grammar), expected_bnf_grammar);
     }

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -18,7 +18,7 @@
 //!     .iter()
 //!     .cloned()
 //!     .collect();
-//! let grammar = Grammar::from(expansios);
+//! let grammar = Grammar::from(&expansios);
 //! assert_eq!(grammar.is_valid_grammar(Some("<string>")), true);
 //! // Fuzzer
 //! let fuzzer = GrammarFuzzer::new(grammar, &strategies);

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -5,7 +5,7 @@
 //! ```
 //! use grammar_fuzzer::Grammar;
 //! use std::collections::HashMap;
-//! 
+//!
 //! let expansios: HashMap<_, _> = [
 //!     ("<list>", vec!["[<values>]"]),
 //!     ("<values>", vec!["<values>, <int>", "<int>"]),
@@ -19,7 +19,7 @@
 //! .cloned()
 //! .collect();
 //!
-//! Grammar::from(expansios);
+//! Grammar::from(&expansios);
 //! ```
 
 use super::parser::{self, Token};
@@ -79,8 +79,8 @@ impl<T> Deref for Grammar<T> {
     }
 }
 
-impl From<HashMap<&str, Vec<&str>>> for Grammar<()> {
-    fn from(input: HashMap<&str, Vec<&str>>) -> Self {
+impl From<&HashMap<&str, Vec<&str>>> for Grammar<()> {
+    fn from(input: &HashMap<&str, Vec<&str>>) -> Self {
         let expansions = input
             .iter()
             .map(|(symbol, expansions)| {
@@ -90,6 +90,28 @@ impl From<HashMap<&str, Vec<&str>>> for Grammar<()> {
                         .iter()
                         .map(|exp| Expansion {
                             string: String::from(*exp),
+                            opts: None,
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
+
+        Grammar::new(expansions)
+    }
+}
+
+impl From<&HashMap<String, Vec<String>>> for Grammar<()> {
+    fn from(input: &HashMap<String, Vec<String>>) -> Self {
+        let expansions = input
+            .iter()
+            .map(|(symbol, expansions)| {
+                (
+                    symbol.clone(),
+                    expansions
+                        .iter()
+                        .map(|exp| Expansion {
+                            string: exp.clone(),
                             opts: None,
                         })
                         .collect(),
@@ -222,7 +244,7 @@ mod tests {
         .iter()
         .cloned()
         .collect();
-        Grammar::from(expansios)
+        Grammar::from(&expansios)
     }
 
     fn invalid_grammar() -> Grammar<()> {
@@ -238,7 +260,20 @@ mod tests {
         .iter()
         .cloned()
         .collect();
-        Grammar::from(expansios)
+        Grammar::from(&expansios)
+    }
+
+    #[test]
+    fn test_grammar_from_string_map() {
+        let expansios: HashMap<String, Vec<String>> = [(
+            String::from("<digit>"),
+            vec![String::from("0"), String::from("1")],
+        )]
+        .iter()
+        .cloned()
+        .collect();
+
+        Grammar::from(&expansios);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!     .cloned()
 //!     .collect();
 //!
-//!     Grammar::from(expansios)
+//!     Grammar::from(&expansios)
 //! }
 //!
 //! fn main() {

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -245,7 +245,7 @@ mod strategy_choose_tests {
         .cloned()
         .collect();
 
-        Grammar::from(expansions)
+        Grammar::from(&expansions)
     }
 
     #[test]


### PR DESCRIPTION
Implements From trait for Grammar to support converting from:
- `&HashMap<&str, Vec<&str>>` and
- `&HashMap<String, Vec<String>>`